### PR TITLE
Arreglando términos de evaluación

### DIFF
--- a/documentos/practicas/5.IaaS.md
+++ b/documentos/practicas/5.IaaS.md
@@ -139,8 +139,7 @@ la práctica.
 Valoración
 --------------
 
-La puntuación de esta práctica es superior al resto, contando como se
-indicó al principio el doble que los otros hitos. 
+La puntuación de esta práctica es superior al resto, contando cada hito de forma proporcional al tiempo invertido en cada hito. 
 
 * 2 puntos: provisionamiento correcta y claramente explicada.
 * 2 puntos: herramienta de orquestación (que cree y despliegue las


### PR DESCRIPTION
Realmente la ponderación se realiza en base a las sesiones dedicadas, no puede valer el doble que el resto porque estas no valen lo mismo, según los criterios de evaluación se ponderan en base a las sesiones tomadas para ellas.