### PR TITLE
Cambio de enlace, creo que al mismo tutorial cambiado de ruta

### DIFF
--- a/documentos/temas/Gestion_de_configuraciones.md
+++ b/documentos/temas/Gestion_de_configuraciones.md
@@ -338,7 +338,7 @@ o
 [incluso desplegar aplicaciones directamente usando el módulo `git`](http://docs.ansible.com/intro_adhoc.html#managing-packages)
 
 Finalmente, el concepto similar a las recetas de Chef en Ansible son los
-[*playbooks*](https://davidwinter.me/articles/2013/11/23/introduction-to-ansible/),
+[*playbooks*](https://davidwinter.dev/introduction-to-ansible/),
 ficheros en YAML que le dicen a la máquina virtual qué es lo que hay
 que instalar en *tareas*, de la forma siguiente
 


### PR DESCRIPTION
El enlace anterior me aparecía con Error 404, creo que solo se ha cambiado la ruta de acceso a ese tutorial.