### PR TITLE
corregido sudo start a docker start

### DIFF
--- a/documentos/temas/Contenedores.md
+++ b/documentos/temas/Contenedores.md
@@ -224,7 +224,7 @@ orden en él tendrás que buscar su nombre:
 
 Posteriormente arrancar el contenedor:
 
-```sudo start <nombre>```
+```docker start <nombre>```
 
 Para finalmente ejecutar el comando deseado:
 


### PR DESCRIPTION
En el tema de Docker, antes de empezar el ejercicio 3 estaba escrito: sudo start <nombre> y debería ser docker start <nombre>. (Creo)