### PR TITLE
Se corrige comentario de instalación para la descarga del script.

### DIFF
--- a/scripts/git-iv
+++ b/scripts/git-iv
@@ -4,7 +4,7 @@
 # Instalación:
 # Prerrequisitos: Perl y git instalados (Perl estará instalado en cualquier Linux)
 # > cd ~/bin # O cualquier otro directorio en el path de ejecución
-# > wget https://raw.githubusercontent.com/JJ/IV/master/scripts/copia-hitos.pl #O bajar el URL a ese directorio de cualquier otra manera
+# > wget https://raw.githubusercontent.com/JJ/IV/master/scripts/git-iv #O bajar el URL a ese directorio de cualquier otra manera
 # > chmod +x git-iv
 # Ya se puede usar a continuación. Por ejemplo
 # > git iv # Para imprimir los subcomandos


### PR DESCRIPTION
Corregido comentario de instalación para descargar script git-iv en lugar de copia-hitos.pl.