### PR TITLE
Fix broken link

### DIFF
--- a/documentos/proyecto/2.Entidad.md
+++ b/documentos/proyecto/2.Entidad.md
@@ -123,7 +123,7 @@ en el mismo que diga "Listo para revisión".
 A este
 [fichero](https://github.com/JJ/IV-21-22/blob/master/proyectos/objetivo-2.md) se
 subirá (mediante un PR *desde una rama*) el nombre del proyecto, el autor y un
-enlace al pull request creado en el repositorio.
+enlace al pull request creado en el repositorio. 
 
 A partir de este hito, habrá que especificar ficheros y otros
 parámetros de configuración para test en un fichero `iv.yaml` que


### PR DESCRIPTION
El enlace al fichero de entrega está roto en la versión .io, al quitar, por algún motivo el .md del final -> (línea 124)
(Añadí un espacio adicional en la línea 126 para poder proponer el cambio)