### PR TITLE
fix: link al objetivo 4

### DIFF
--- a/documentos/proyecto/1.Planificacion.md
+++ b/documentos/proyecto/1.Planificacion.md
@@ -227,7 +227,7 @@ El siguiente producto tendrá que incluir la lógica de negocio, así como la
 infraestructura necesaria para comprobar automáticamente su validez; en este
 *milestone* y en todos los sucesivos la validez se establecerá, al menos en la
 parte de calidad, automáticamente. Por eso [corresponde al objetivo 4 de la
-asignatura](https://jj.github.io/IV/documentos/proyecto/2.Entidad) donde se
+asignatura](https://jj.github.io/IV/documentos/proyecto/4.Tests) donde se
 programa la lógica de negocio y se escriben (y ejecutan automáticamente en
 objetivos sucesivos) los primeros tests.
 


### PR DESCRIPTION
El link al que se hace referencia apuntaba al objetivo 2 en vez de al 4.